### PR TITLE
Fixed a broken link and added whitespace

### DIFF
--- a/faqs/01_cs-ai.toml
+++ b/faqs/01_cs-ai.toml
@@ -709,7 +709,7 @@ If possible, you should therefore try not to let it get that far: In any case, p
 1. You ask the LVA instructor whether there are other options for taking the exam.
 2. You take a similar subject from a different study at JKU and have it transferred - see e.g. [these lists](https://cs.jku.at/teaching/stuko/credittransfer/) of equivalent courses.
 3. You take the subject at another university and have it recognized at JKU: However, this is easier said than done - you can generally only take subjects at other universities if they are not already offered at JKU (§ 63 Abs. 9 UG). The subject must therefore be different enough for co-enrollment, but similar enough for credit transfer - this topic must therefore always be discussed with your study coordinator. This limitation does not apply to a semester abroad.
-4.You wait for a change in the curriculum: Sometimes LVAs change (for example due to renaming) and are given a new course number. In this case, your attempts are often reset, so the course is treated as a new course. To be on the safe side, ask the Examination and Recognition Service whether such a change has been made.
+4. You wait for a change in the curriculum: Sometimes LVAs change (for example due to renaming) and are given a new course number. In this case, your attempts are often reset, so the course is treated as a new course. To be on the safe side, ask the Examination and Recognition Service whether such a change has been made.
 '''
 
 [[sections.subsections.questions]]

--- a/faqs/01_cs-ai.toml
+++ b/faqs/01_cs-ai.toml
@@ -473,7 +473,7 @@ Depending on your citizenship, you will also need to pay tuition fees: EU and EE
 
 Note that for some financial aids (e.g. Studienbeihilfe), the amount of tolerance semesters before funding is cut is lower.
 
-During the Bachelor’s, keep [Mindeststudienleistung](http://localhost:8000/cs-ai/en/#what-is-the-minimum-number-of-credits-mindeststudienleistung) in mind.
+During the Bachelor’s, keep [Mindeststudienleistung](#what-is-the-minimum-number-of-credits-mindeststudienleistung) in mind.
 '''
 
 [[sections.subsections.questions]]


### PR DESCRIPTION
The link referencing Mindeststudienleistung was pointing to `http://localhost:8000/cs-ai/en/#what-is-the-minimum-number-of-credits-mindeststudienleistung`, changed it point to the appropriate question instead.

Whitespace was missing in one of the ordered lists causing it not to be rendered properly in the English version. Added the missing whitespace.